### PR TITLE
added installer script

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,29 +7,29 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-- 
-  env:
-  - CGO_ENABLED=0
-  ldflags:
-  - -s -w -X github.com/karimra/gnmiClient/cmd.version={{.Version}} -X github.com/karimra/gnmiClient/cmd.commit={{.ShortCommit}} -X github.com/karimra/gnmiClient/cmd.date={{.Date}} -X github.com/karimra/gnmiClient/cmd.gitURL={{.GitURL}}
-  goos:
-  - linux
-  - darwin
-  - windows
+  - env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/karimra/gnmiClient/cmd.version={{.Version}} -X github.com/karimra/gnmiClient/cmd.commit={{.ShortCommit}} -X github.com/karimra/gnmiClient/cmd.date={{.Date}} -X github.com/karimra/gnmiClient/cmd.gitURL={{.GitURL}}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ .Tag }}"
 changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,12 +17,14 @@ builds:
       - windows
     goarch:
       - amd64
+      - 386
 archives:
   - replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows
       amd64: x86_64
+      386: i386
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,14 @@
 TAR_PREFIX=gnmiClient
 PLATFORM=$(uname)
 ARCH=$(uname -m)
+INSTALLED_VERSION=$(gnmiClient version | grep version | awk '{print $3}') || ""
 LATEST_URL=$(curl -s https://github.com/karimra/gnmiClient/releases/latest | cut -d '"' -f 2)
 LATEST_TAG=$(echo "${LATEST_URL: -6}")
 TAG_WO_VER=$(echo "${LATEST_URL: -6}" | cut -c 2-)
+if [ "$INSTALLED_VERSION" == "$TAG_WO_VER" ]; then
+    echo "You have the latest gnmiClient version installed: $INSTALLED_VERSION"
+    exit 0
+fi
 FNAME="${TAR_PREFIX}_${TAG_WO_VER}_${PLATFORM}_${ARCH}.tar.gz"
 echo "Downloading $FNAME..."
 (cd /tmp && curl -ksLO https://github.com/karimra/gnmiClient/releases/download/"$LATEST_TAG"/"$FNAME")

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,16 @@
+TAR_PREFIX=gnmiClient
+PLATFORM=$(uname)
+ARCH=$(uname -m)
+LATEST_URL=$(curl -s https://github.com/karimra/gnmiClient/releases/latest | cut -d '"' -f 2)
+LATEST_TAG=$(echo "${LATEST_URL: -6}")
+TAG_WO_VER=$(echo "${LATEST_URL: -6}" | cut -c 2-)
+FNAME="${TAR_PREFIX}_${TAG_WO_VER}_${PLATFORM}_${ARCH}.tar.gz"
+echo "Downloading $FNAME..."
+(cd /tmp && curl -ksLO https://github.com/karimra/gnmiClient/releases/download/"$LATEST_TAG"/"$FNAME")
+tar -xzf /tmp/${FNAME} -C /tmp
+echo "Moving gnmiClient to /usr/local/bin"
+echo
+mv /tmp/gnmiClient /usr/local/bin
+/usr/local/bin/gnmiClient version
+echo
+echo "Installation complete!"


### PR DESCRIPTION
This PR adds an `install.sh` script that downloads the `latest` binary, untars the client and installs it under `/usr/local/bin` for the relative platform and arch (Darwin/Linux | x64)

To install the gnmiClient the end user can use the following one liner

```bash
# note the URL will change to master blob if/once merged
curl -s https://raw.githubusercontent.com/karimra/gnmiClient/installer/install.sh | sh
```

example output:

```
$ curl -s https://raw.githubusercontent.com/karimra/gnmiClient/installer/install.sh | sh
Downloading gnmiClient_0.0.2_Darwin_x86_64.tar.gz...
Moving gnmiClient to /usr/local/bin

version : 0.0.2
 commit : 6421307
   date : 2020-04-13T00:43:09Z
 gitURL : https://github.com/karimra/gnmiClient.git

Installation complete!
```

If the installed version of gnmiClient matches the latest available release, the binary won't be downloaded and installation will stop:
```
$ bash install.sh 
You have the latest gnmiClient version installed: 0.0.2
```

### future development
later we can add:
1. checksum verification
2. version picker