### PR TITLE
added time for get messages

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/gnxi/utils/xpath"
@@ -183,6 +184,8 @@ func printGetResponse(printPrefix string, response *gnmi.GetResponse) {
 	for _, notif := range response.Notification {
 		msg := new(msg)
 		msg.Timestamp = notif.Timestamp
+		t := time.Unix(0, notif.Timestamp)
+		msg.Time = &t
 		msg.Prefix = gnmiPathToXPath(notif.Prefix)
 		for i, upd := range notif.Update {
 			if upd.Val == nil {

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -33,10 +33,11 @@ import (
 )
 
 type msg struct {
-	Timestamp int64     `json:"timestamp,omitempty"`
-	Prefix    string    `json:"prefix,omitempty"`
-	Updates   []*update `json:"updates,omitempty"`
-	Deletes   []string  `json:"deletes,omitempty"`
+	Timestamp int64      `json:"timestamp,omitempty"`
+	Time      *time.Time `json:"time,omitempty"`
+	Prefix    string     `json:"prefix,omitempty"`
+	Updates   []*update  `json:"updates,omitempty"`
+	Deletes   []string   `json:"deletes,omitempty"`
 }
 type update struct {
 	Path   string


### PR DESCRIPTION
Fixes #11

Added time for `get` only, since subscribe has a time information provided for every update

examples:

```
2020/05/20 21:53:29.397846 sending gnmi GetRequest 'path:<elem:<name:"state" > elem:<name:"system" > elem:<name:"version" > > ' to 0.tcp.eu.ngrok.io:11419
{
  "timestamp": 1590004439584441124,
  "time": "2020-05-20T21:53:59.584441124+02:00",
  "updates": [
    {
      "Path": "state/system/version",
      "values": {
        "state/system/version": {
          "version-number": "B-20.5.R1",
          "version-string": "TiMOS-B-20.5.R1 both/x86_64 Nokia 7750 SR Copyright (c) 2000-2020 Nokia.\r\nAll rights reserved. All use subject to applicable license agreements.\r\nBuilt on Wed May 13 14:08:50 PDT 2020 by builder in /builds/c/205B/R1/panos/main/sros"
        }
      }
    }
  ]
}
```