### PR TITLE
fix #30 - textproto output fails for Get RPC

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/google/gnxi/utils/xpath"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/spf13/cobra"
@@ -178,7 +178,7 @@ func init() {
 
 func printGetResponse(printPrefix string, response *gnmi.GetResponse) {
 	if viper.GetString("format") == "textproto" {
-		fmt.Printf("%s\n", indent(printPrefix, proto.MarshalTextString(response)))
+		fmt.Printf("%s\n", proto.MarshalTextString(response))
 		return
 	}
 	for _, notif := range response.Notification {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -23,12 +23,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/gnxi/utils/xpath"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/prototext"
 )
 
 // getCmd represents the get command
@@ -178,7 +178,7 @@ func init() {
 
 func printGetResponse(printPrefix string, response *gnmi.GetResponse) {
 	if viper.GetString("format") == "textproto" {
-		fmt.Printf("%s\n", proto.MarshalTextString(response))
+		fmt.Printf("%s\n", indent(printPrefix, prototext.Format(response)))
 		return
 	}
 	for _, notif := range response.Notification {

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -24,12 +24,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/gnxi/utils/xpath"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/prototext"
 )
 
 type msg struct {
@@ -317,7 +317,7 @@ func printSubscribeResponse(meta map[string]interface{}, subResp *gnmi.Subscribe
 	switch resp := subResp.Response.(type) {
 	case *gnmi.SubscribeResponse_Update:
 		if viper.GetString("format") == "textproto" {
-			fmt.Printf("%s\n", proto.MarshalTextString(subResp))
+			fmt.Printf("%s\n", prototext.Format(subResp))
 			return
 		}
 		msg := new(msg)

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,6 @@ require (
 	github.com/spf13/viper v1.6.2
 	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
 	google.golang.org/grpc v1.29.1
+	google.golang.org/protobuf v1.23.0
 	gopkg.in/yaml.v2 v2.2.4
 )


### PR DESCRIPTION
closes #30 

sample output:

```
❯ go run . --insecure get --path /state/system/version --format textproto
2020/06/04 21:47:16.747007 sending gnmi GetRequest 'path:{elem:{name:"state"}  elem:{name:"system"}  elem:{name:"version"}}' to 0.tcp.eu.ngrok.io:12267
notification: <
  timestamp: 1591300074946815031
  update: <
    path: <
      elem: <
        name: "state"
      >
      elem: <
        name: "system"
      >
      elem: <
        name: "version"
      >
    >
    val: <
      json_val: "{\n    \"version-number\": \"B-20.5.R1\",\n    \"version-string\": \"TiMOS-B-20.5.R1 both/x86_64 Nokia 7750 SR Copyright (c) 2000-2020 Nokia.\\r\\nAll rights reserved. All use subject to applicable license agreements.\\r\\nBuilt on Wed May 13 14:08:50 PDT 2020 by builder in /builds/c/205B/R1/panos/main/sros\"\n}"
    >
  >
>
```