### PR TITLE
deanonimize set request goroutine

### DIFF
--- a/cmd/set.go
+++ b/cmd/set.go
@@ -480,11 +480,11 @@ func convert(i interface{}) interface{} {
 	return i
 }
 func printSetRequest(printPrefix string, request *gnmi.SetRequest) {
-	fmt.Printf("%sSet Request: \n", printPrefix)
 	if viper.GetString("format") == "textproto" {
 		fmt.Printf("%s\n", indent("  ", prototext.Format(request)))
 		return
 	}
+	fmt.Printf("%sSet Request: \n", printPrefix)
 	req := new(setReqMsg)
 	req.Prefix = gnmiPathToXPath(request.Prefix)
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -487,29 +487,29 @@ func printSetRequest(printPrefix string, request *gnmi.SetRequest) {
 	fmt.Printf("%sSet Request: \n", printPrefix)
 	req := new(setReqMsg)
 	req.Prefix = gnmiPathToXPath(request.Prefix)
+	req.Delete = make([]string, 0, len(request.Delete))
+	req.Replace = make([]*updateMsg, 0, len(request.Replace))
+	req.Update = make([]*updateMsg, 0, len(request.Update))
 
-	if len(request.Delete) > 0 {
-		for _, del := range request.Delete {
-			p := gnmiPathToXPath(del)
-			req.Delete = append(req.Delete, p)
-		}
+	for _, del := range request.Delete {
+		p := gnmiPathToXPath(del)
+		req.Delete = append(req.Delete, p)
 	}
-	if len(request.Replace) > 0 {
-		for _, upd := range request.Replace {
-			updMsg := new(updateMsg)
-			updMsg.Path = gnmiPathToXPath(upd.Path)
-			updMsg.Val = fmt.Sprintf("%s", upd.Val)
-			req.Replace = append(req.Replace, updMsg)
-		}
+
+	for _, upd := range request.Replace {
+		updMsg := new(updateMsg)
+		updMsg.Path = gnmiPathToXPath(upd.Path)
+		updMsg.Val = fmt.Sprintf("%s", upd.Val)
+		req.Replace = append(req.Replace, updMsg)
 	}
-	if len(request.Update) > 0 {
-		for _, upd := range request.Update {
-			updMsg := new(updateMsg)
-			updMsg.Path = gnmiPathToXPath(upd.Path)
-			updMsg.Val = fmt.Sprintf("%s", upd.Val)
-			req.Update = append(req.Update, updMsg)
-		}
+
+	for _, upd := range request.Update {
+		updMsg := new(updateMsg)
+		updMsg.Path = gnmiPathToXPath(upd.Path)
+		updMsg.Val = fmt.Sprintf("%s", upd.Val)
+		req.Update = append(req.Update, updMsg)
 	}
+
 	b, err := json.MarshalIndent(req, "", "  ")
 	if err != nil {
 		fmt.Println("failed marshaling the set request", err)


### PR DESCRIPTION
rationale as in #38 

A few modifications have been made:

1. added logging message with SetRequest body to be inline with other RPCs.
2. substitute the textproto format from using protobuf encoder to `proto.MarshalTextString`

What I am a bit concerned about is 
1. if it is needed to print the SetRequest as it is now in the YAML format
    ```
    2020/06/10 20:54:21.616734 sending gNMI SetRequest: 'prefix:{}  update:{path:{elem:{name:"configure"}  elem:{name:"system"}  elem:{name:"name"}}  val:{json_val:"\"R1_20.5.r1_new\""}}' to 2.tcp.eu.ngrok.io:18772
    Request: 
    prefix: 
        update:
        path : configure/system/name
        value: json_val:"\"R1_20.5.r1_new\""
    ```

    Maybe the log message is enough? It may not be enough when the more elaborated set is in use...

2. If it is needed, maybe we should change to JSON styled response to be inline with Get and Subscribe? Currently the output is in YAML format as well