### PR TITLE
Refactored subscribe cmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -357,7 +357,7 @@ func setupCloseHandler(cancelFn context.CancelFunc) {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
 	go func() {
 		sig := <-c
-		fmt.Printf("received signal '%s'. terminating...\n", sig.String())
+		fmt.Printf("\nreceived signal '%s'. terminating...\n", sig.String())
 		cancelFn()
 		os.Exit(0)
 	}()


### PR DESCRIPTION
I am not fully satisfied with the way the log message for subscribe request is:

```
2020/06/12 21:22:34.159138 sending gnmi SubscribeRequest: subscribe='subscribe:{prefix:{}  subscription:{path:{elem:{name:"state"}  elem:{name:"system"}  elem:{name:"version"}}  sample_interval:10000000000}  subscription:{path:{elem:{name:"state"}  elem:{name:"system"}  elem:{name:"version"}  elem:{name:"version-string"}}  sample_interval:10000000000}  qos:{marking:20}  encoding:BYTES}', mode='STREAM', encoding='BYTES', to XXX:12753
```

my concern is with the format of this message, its not following the nesting of the gNMI messages, where you have a bit different structure.

A minor thing, but maybe worth to track in another issue later on